### PR TITLE
Fix phishing filter's handling of explicit :80

### DIFF
--- a/mailscanner/bin/MailScanner/Message.pm
+++ b/mailscanner/bin/MailScanner/Message.pm
@@ -7594,7 +7594,7 @@ sub CleanLinkURL {
   $linkurl = $DisarmBaseURL . '/' . $linkurl
     if $linkurl ne "" && $DisarmBaseURL ne "" &&
        $linkurl !~ /^(https?|ftp|mailto|webcal):/i;
-  $linkurl =~ s/^(https?:\/\/[^:]+):80($|\D)/$1/i; # Remove http://....:80
+  $linkurl =~ s/^(https?:\/\/[^:]+):80($|\D)/$1$2/i; # Remove http://....:80
   $linkurl =~ s/^(https?|ftp|webcal)[:;]\/\///i;
   return ("",0) if $linkurl =~ /^ma[il]+to[:;]/i;
   #$linkurl = "" if $linkurl =~ /^ma[il]+to[:;]/i;
@@ -7605,7 +7605,6 @@ sub CleanLinkURL {
   return ("",0) if $linkurl =~ /^#/; # Ignore internal links completely
   #$linkurl = "" if $linkurl =~ /^#/; # Ignore internal links completely
   $linkurl =~ s/\/$//; # LinkURL is trimmed -- note
-  $linkurl =~ s/:80$//; # Port 80 is the default anyway
   $alarm = 1 if $linkurl =~ s/[\x00-\x1f[:^ascii:]]/_BAD_/g; # /\&\#/;
   $linkurl = 'JavaScript' if $linkurl =~ /^javascript:/i;
   ($linkurl, $alarm);

--- a/mailscanner/etc/phishing.safe.sites.conf
+++ b/mailscanner/etc/phishing.safe.sites.conf
@@ -435,7 +435,7 @@ newsletters.microsoft.com
 newsletters.openmoves.com
 newsletter.yvesrocher.ca
 newsmailer.hilti.biz
-news.national.com:80
+news.national.com
 news.occupationalhazards.com
 news.sonypictures.com
 news.topgratuit.com
@@ -559,7 +559,6 @@ shopper.cnet.com
 skype.com
 *.smartbrief.com
 smr.mm.ticketmaster.com
-smr.mm.ticketmaster.com:80
 snaps.vidiemi.com
 *.sndforclnt1.com
 *.sndforclnt2.com


### PR DESCRIPTION
The phishing filter erroneously handled URLs like
http://example.com:80/phish/stuff, parsing it as example.comphish

Patch fixes that, and removes erroneous entries ending in :80 in
phishing.safe.sites.conf
