### PR TITLE
Update SMDiskStore.pm

### DIFF
--- a/mailscanner/bin/MailScanner/SMDiskStore.pm
+++ b/mailscanner/bin/MailScanner/SMDiskStore.pm
@@ -329,8 +329,8 @@ sub ReadBody {
       push @{$body}, $lastlineread;
       #print STDERR "Line read is ****" . $_ . "****\n";
     }
-    # A user reports SpamAssassin fails if the body doesn't end with newline
-    if ($body->[@{$body}-1] =~ /^.*\z/) {
+    # A user reports SpamAssassin fails if the body doesn't end with an empty line
+    if ($body->[@{$body}-1] !~ /^$/) {
       push @{$body}, "\n";
     }
     return;
@@ -354,8 +354,8 @@ sub ReadBody {
     #print STDERR "Line read2 is ****" . $line . "****\n";
   }
   $lastlineread = $line;
-  # A user reports SpamAssassin fails if the body doesn't end with newline
-  if ($body->[@{$body}-1] =~ /^.*\z/) {
+  # A user reports SpamAssassin fails if the body doesn't end with an empty line
+  if ($body->[@{$body}-1] !~ /^$/) {
     push @{$body}, "\n";
   }
 
@@ -411,8 +411,8 @@ sub ReadBody {
       $lastlineread = <$dh>;
       #print STDERR "Added $lastlineread";
     }
-    # A user reports SpamAssassin fails if the body doesn't end with newline
-    if ($body->[@{$body}-1] =~ /^.*\z/) {
+    # A user reports SpamAssassin fails if the body doesn't end with an empty line
+    if ($body->[@{$body}-1] !~ /^$/) {
       push @{$body}, "\n";
     }
 

--- a/mailscanner/bin/MailScanner/SMDiskStore.pm
+++ b/mailscanner/bin/MailScanner/SMDiskStore.pm
@@ -329,6 +329,10 @@ sub ReadBody {
       push @{$body}, $lastlineread;
       #print STDERR "Line read is ****" . $_ . "****\n";
     }
+    # A user reports SpamAssassin fails if the body doesn't end with newline
+    if ($body->[@{$body}-1] =~ /^.*\z/) {
+      push @{$body}, "\n";
+    }
     return;
   }
 
@@ -350,6 +354,10 @@ sub ReadBody {
     #print STDERR "Line read2 is ****" . $line . "****\n";
   }
   $lastlineread = $line;
+  # A user reports SpamAssassin fails if the body doesn't end with newline
+  if ($body->[@{$body}-1] =~ /^.*\z/) {
+    push @{$body}, "\n";
+  }
 
   #print STDERR "Initially read $size bytes\n";
 
@@ -402,6 +410,10 @@ sub ReadBody {
       push @{$body}, $lastlineread;
       $lastlineread = <$dh>;
       #print STDERR "Added $lastlineread";
+    }
+    # A user reports SpamAssassin fails if the body doesn't end with newline
+    if ($body->[@{$body}-1] =~ /^.*\z/) {
+      push @{$body}, "\n";
     }
 
     return;


### PR DESCRIPTION
Wolfgang Baudler <wbaudler@gb.nrao.edu> reports that email bodies which do not end with an empty line cause SpamAssassin to miss rules that should hit. In his installation, ensuring that the results of ReadBody() always end with a newline fixes the issue.

I don't have a sendmail test environment. I can't duplicate the issue with Postfix, and I can't test this fix, but I *think* it should be OK. It should be tested in a sendmail environment before merging.