### PR TITLE
Updates to Debian scripts

### DIFF
--- a/Debian.files/etc/cron.hourly/mailscanner
+++ b/Debian.files/etc/cron.hourly/mailscanner
@@ -34,7 +34,7 @@ if [ -z "$PIDS" ]; then
 		rm -f $PIDFILE
 	fi
 	
-	/usr/bin/service MailScanner restart >/dev/null 2>&1;
+	/usr/bin/service MailScanner start >/dev/null 2>&1;
 fi
 
 exit 0;

--- a/Debian.files/etc/init.d/mailscanner
+++ b/Debian.files/etc/init.d/mailscanner
@@ -211,6 +211,7 @@ case "$1" in
 	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
 	
 	do_stop
+	RETVAL="$?"
 	
 	if [ $ramdisk_sync = 1 ]; then
 		# make sure this is a RAMDISK tmpfs
@@ -229,7 +230,7 @@ case "$1" in
 			rsync --quiet --archive --delete --recursive --force ${work_dir}/ ${ramdisk_store}
 		fi
 	fi
-	case "$?" in
+	case "$RETVAL" in
 		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
 		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
 	esac


### PR DESCRIPTION
The init.d script had an issue in the stop case because the backup the ramdisk code lost the return status from do_stop()

The cron.hourly script is probably OK as is, but I think it should just do start, not restart.