### PR TITLE
Don't loose message on Disarm DoS attack

### DIFF
--- a/mailscanner/bin/MailScanner/ConfigDefs.pl
+++ b/mailscanner/bin/MailScanner/ConfigDefs.pl
@@ -634,6 +634,7 @@ InsistPassZips		0	no	0	yes	1
 NewHeadersAtTop		0	no	0	yes	1
 PhishingNumbers		1	no	0	yes	1
 QuarantineInfections	1	no	0	yes	1
+QuarantineDenialOfService	1	no	0	yes	1
 QuarantineModifiedBody	0	no	0	yes	1
 QuarantineSilent	0	no	0	yes	1
 QuarantineWholeMessage	0	no	0	yes	1

--- a/mailscanner/bin/MailScanner/Message.pm
+++ b/mailscanner/bin/MailScanner/Message.pm
@@ -7793,10 +7793,16 @@ sub DeleteAllRecipients {
 sub QuarantineDOS {
     my($message) = @_;
 
+    if (MailScanner::Config::Value ('quarantinedenialofservice', $message) !~ /1/) {
+        MailScanner::Log::WarnLog('Dropping message %s as it caused MailScanner to crash several times', $message->{id});
+        last;
+    };
+
     MailScanner::Log::WarnLog('Quarantined message %s as it caused MailScanner to crash several times', $message->{id});
 
     $message->{quarantinedinfections} = 1; # Stop it quarantining it twice
     $message->{deleted} = 1;
+    $message->{denialofservice} = 1;
     $message->{abandoned} = 1;
     $message->{stillwarn} = 1;
     $message->{infected} = 1;

--- a/mailscanner/bin/MailScanner/Message.pm
+++ b/mailscanner/bin/MailScanner/Message.pm
@@ -6812,6 +6812,7 @@ sub DisarmHTMLTree {
     #print STDERR "Disarmed = " . join(', ',@disarmed) . "\n";
     if (@disarmed) {
       $this->{bodymodified} = 1;
+      $this->{denialofservice} = 1 if grep(/^denialofservice$/, @disarmed);
       $DisarmHTMLChangedMessage = 1;
       $counter++;
     }
@@ -6928,6 +6929,7 @@ sub DisarmHTMLEntity {
                                 $newname);
       exit 1;
     }
+
     select $outfh;
     if ($DisarmPhishing) {
       HTML::Parser->new(api_version => 3,
@@ -7034,9 +7036,8 @@ sub DisarmHTMLEntity {
     $report = $report2 if $report2 && $report2 ne 'htmlparserattack';
     print $outfh $report . "\n\nAttack in: $oldname\n";
     $outfh->close;
-    #print STDERR "HTML::Parser was killed by the message, " .
-    #             "$newname has been overwritten\n";
-    return ('KILLED');
+    
+    push @DisarmDoneSomething, 'denialofservice';
   }
 
   #print STDERR "Results of HTML::Parser are " . join(',',@DisarmDoneSomething) . "\n";

--- a/mailscanner/bin/MailScanner/MessageBatch.pm
+++ b/mailscanner/bin/MailScanner/MessageBatch.pm
@@ -758,6 +758,28 @@ sub QuarantineInfections {
   }
 }
 
+# Store all the denial-of-service message in the quarantine if they want me to.
+# Quarantine decision has to be done on a per-message basis.
+sub QuarantineDenialOfService {
+  my $this = shift;
+
+  my($id, $message);
+
+  while(($id, $message) = each %{$this->{messages}}) {
+    next unless $message->{denialofservice};
+    next if $message->{quarantinedinfections}; # Optimisation
+    next if MailScanner::Config::Value ('quarantinedenialofservice', $message) !~
+            /1/;
+
+	# force full message store
+	$message->{allreports}{""} .= ' denialofservice';
+
+    $global::MS->{quar}->StoreInfections($message);
+    MailScanner::Log::NoticeLog("Quarantining DoS message for %s", $id);
+  }
+}
+
+
 # Store all the disarmed files in the quarantine if they want me to.
 # Quarantine decision has to be done on a per-message basis.
 sub QuarantineModifiedBody {

--- a/mailscanner/bin/MailScanner/MessageBatch.pm
+++ b/mailscanner/bin/MailScanner/MessageBatch.pm
@@ -760,7 +760,7 @@ sub QuarantineInfections {
 
 # Store all the denial-of-service message in the quarantine if they want me to.
 # Quarantine decision has to be done on a per-message basis.
-sub QuarantineDenialOfService {
+sub QuarantineDOS {
   my $this = shift;
 
   my($id, $message);
@@ -768,14 +768,8 @@ sub QuarantineDenialOfService {
   while(($id, $message) = each %{$this->{messages}}) {
     next unless $message->{denialofservice};
     next if $message->{quarantinedinfections}; # Optimisation
-    next if MailScanner::Config::Value ('quarantinedenialofservice', $message) !~
-            /1/;
 
-	# force full message store
-	$message->{allreports}{""} .= ' denialofservice';
-
-    $global::MS->{quar}->StoreInfections($message);
-    MailScanner::Log::NoticeLog("Quarantining DoS message for %s", $id);
+    $message->QuarantineDOS();
   }
 }
 

--- a/mailscanner/bin/mailscanner.sbin
+++ b/mailscanner/bin/mailscanner.sbin
@@ -1234,7 +1234,7 @@ sub WorkForHours {
     #$batch->QuarantineInfections();
 
     # Quarantine all denial-of-service attempt
-    $batch->QuarantineDenialOfService();
+    $batch->QuarantineDOS();
 
     # Quarantine all the disarmed HTML and others
     $batch->QuarantineModifiedBody();

--- a/mailscanner/bin/mailscanner.sbin
+++ b/mailscanner/bin/mailscanner.sbin
@@ -1233,6 +1233,9 @@ sub WorkForHours {
     #$0 = 'MailScanner: quarantining infections';
     #$batch->QuarantineInfections();
 
+    # Quarantine all denial-of-service attempt
+    $batch->QuarantineDenialOfService();
+
     # Quarantine all the disarmed HTML and others
     $batch->QuarantineModifiedBody();
 

--- a/mailscanner/etc/mailscanner.conf
+++ b/mailscanner/etc/mailscanner.conf
@@ -1284,6 +1284,11 @@ Quarantine Infections = yes
 Quarantine Silent Viruses = no
 
 # Do you want to store copies of messages which have been disarmed by
+# Denial of Service protection?
+# This can also be the filename of a ruleset.
+Quarantine Denial Of Service = yes
+
+# Do you want to store copies of messages which have been disarmed by
 # having their HTML modified at all?
 # This can also be the filename of a ruleset.
 Quarantine Modified Body = no


### PR DESCRIPTION
I found a severe issue with MailScanner that happens every time the server is under heavy load.
# The Issue

```
Mar 14 16:58:50 mail MailScanner[1234]: Content Checks: Detected and have disarmed KILLED tags in HTML message in 05C7D4013C.A7BCC from someone@example.com
```

When MailScanner need to disarm the code if forks, so that any exploit could not affect the parent process. The problem is that if the child die for whatever reason (heavy load, malloc failed, parser bugs, ...), the parent replace a part of the message with a scary message and completely destroy the original message
# My Solution

First of all, in the DoS procedure I've added `$msg->{bodymodified} = 1` so that the change to the file is tracked correctly by MailScanner, and can be logged if `Quarantine Modified Body` option is enabled. This option alone is not enough, anyway. Modification to the body are done in a "controlled" way by the postmaster, so it is always safe to disable this option on production. On the other hand, the DoS prevention is hard-coded to MailScanner and therefore it deserve a new option defaulting to true. I've added `Quarantine Denial Of Service` option for this, but it can be extended in future release to include other DoS prevention when appropriate.
