### PR TITLE
Do not deliver message with whole content unparsable

### DIFF
--- a/mailscanner/bin/MailScanner/Message.pm
+++ b/mailscanner/bin/MailScanner/Message.pm
@@ -2437,8 +2437,7 @@ sub Explode {
       if ($boundary eq "" || $boundary eq "\"\"" || $boundary =~ /\s$/) {
         my $cantparse = MailScanner::Config::LanguageValue($this,
                                                            'cantanalyze');
-        $this->{allreports}{""} .= "$mailscannername: $cantparse\n";
-        $this->{alltypes}{""} .= 'c';
+        $this->{cantparse} = 1;
         $this->{otherinfected}++;
         #print STDERR "Found error\n";
       }


### PR DESCRIPTION
There is a bad behaviour with malformed multipart messages. This happens when a message containes the following snippet (for example):

```
Content-Type: multipart/mixed;
?boundary="LONG_HASH"
```

Note the spurious question mark. In this situation the message is completely replaced by a configured message and sent to the user, but it can't hardly find something useful there. It is much better to quarantine the message and prevent the sending.

The fix is quite simple, as MailScanner already handle a `cantparse` situation and I've just joined two very similar situations. In the end, the message is saved in the quarantine, the log message is the same as before, but the useless placeholder message is prevented.
